### PR TITLE
[fix] useContext 버그 수정 #16

### DIFF
--- a/src/boostact/Boostact.js
+++ b/src/boostact/Boostact.js
@@ -6,6 +6,8 @@ let nextVNode = null;
 let element;
 let component;
 let container;
+const defaultContext = [];
+let currentContext;
 
 const deletionQueue = [];
 const FIRST_CHILD = 0;
@@ -13,6 +15,8 @@ const INIT_VALUE = 0;
 
 const HOOKS = [];
 let HOOK_ID = 0;
+const CONTEXTS = [];
+let CONTEXT_ID = 0;
 
 const initHook = () => {
   HOOKS.forEach((hook, index) => {
@@ -21,6 +25,7 @@ const initHook = () => {
     }
   });
   HOOKS.length = HOOK_ID;
+  currentContext = defaultContext;
   return HOOKS;
 };
 
@@ -71,7 +76,11 @@ const appendVNode = (vNode, children) => {
     let vChild = null;
     if (children && children[index] !== undefined) {
       vChild = { ...children[index] };
-
+      if (children[index].context) {
+        currentContext = children[index].context;
+      } else {
+        currentContext = vNode.context;
+      }
       if (typeof vChild.type === "function") {
         vChild = vChild.type(vChild.props);
 
@@ -81,6 +90,7 @@ const appendVNode = (vNode, children) => {
           continue;
         }
       }
+      vChild.context = currentContext;
     }
 
     if (vChild) {
@@ -143,6 +153,7 @@ const makeVRoot = () => {
     },
     child: currentRoot && currentRoot.child,
     effectTag: currentRoot && currentRoot.type === component.type ? "UPDATE" : "PLACEMENT",
+    context: [...defaultContext],
   };
 
   return temp;
@@ -202,6 +213,7 @@ const determineState = (curChild, vChild) => {
 };
 
 const render = (el, root) => {
+  debugger;
   element = el;
   container = root;
   vRoot = makeVRoot();
@@ -385,21 +397,27 @@ const useEffect = (fn, arr) => {
 };
 
 const useContext = (context) => {
-  return context.value[context.value.length - 1];
+  return currentContext[context.id];
 };
 
 const createContext = (defaultValue) => {
-  const CURRENT_HOOK_ID = HOOK_ID++;
+  const CURRENT_CONTEXT_ID = CONTEXT_ID++;
+  defaultContext[CURRENT_CONTEXT_ID] = defaultValue;
+  currentContext = defaultContext;
   const useContextHook = {
-    value: [defaultValue],
+    id: CURRENT_CONTEXT_ID,
     Provider: (props) => {
-      HOOKS[CURRENT_HOOK_ID].value.push(props.value);
-      return { type: "CONTEXT", props: { children: props.children }, hook: HOOKS[CURRENT_HOOK_ID] };
+      const newContext = [...currentContext];
+      newContext[CURRENT_CONTEXT_ID] = props.value;
+      props.children.forEach((child) => {
+        child.context = newContext;
+      });
+      return { type: "CONTEXT", props: { children: props.children } };
     },
   };
 
-  HOOKS[CURRENT_HOOK_ID] = HOOKS[CURRENT_HOOK_ID] || useContextHook;
-  return HOOKS[CURRENT_HOOK_ID];
+  CONTEXTS[CURRENT_CONTEXT_ID] = CONTEXTS[CURRENT_CONTEXT_ID] || useContextHook;
+  return CONTEXTS[CURRENT_CONTEXT_ID];
 };
 
 export default { render, createElement, useState, useEffect, createContext, useContext, useReducer, initHook, reRender };


### PR DESCRIPTION
- 여러상황에서도 useContext가 되도록 구현

## :lock: 관련 이슈(닫을 이슈)
- #16 

## :white_check_mark: 작업 내용
- UseContext 구현

## :hammer: 변경 로직
- 전역에 변수 선언 후 각 컴포넌트들의 함수를 수행할때 부모의 Context를 저장 함수는 부모의 Context를 참조함.
