### PR TITLE
[fix] : 중복으로 render 함수 호출 시 제대로 적용이 안되는 묹제 해결

### DIFF
--- a/src/boostact/Boostact.js
+++ b/src/boostact/Boostact.js
@@ -213,7 +213,6 @@ const determineState = (curChild, vChild) => {
 };
 
 const render = (el, root) => {
-  debugger;
   element = el;
   container = root;
   vRoot = makeVRoot();
@@ -222,7 +221,11 @@ const render = (el, root) => {
 
 const reRender = () => {
   if (!nextVNode) {
+    HOOK_ID = 0;
     vRoot = makeVRoot();
+    if(nextVNode){
+      vRoot = nextVNode;
+    }
     nextVNode = vRoot;
   }
 };
@@ -372,11 +375,11 @@ const useEffect = (fn, arr) => {
       if (el !== arr[i]) {
         HOOKS[CURRENT_HOOK_ID].beforeArr = arr;
         if (typeof HOOKS[CURRENT_HOOK_ID].cleanUp === "function") HOOKS[CURRENT_HOOK_ID].cleanUp();
+        HOOKS[CURRENT_HOOK_ID].work = fn;
         HOOKS[CURRENT_HOOK_ID].cleanUp = HOOKS[CURRENT_HOOK_ID].work();
         if (HOOKS[CURRENT_HOOK_ID].cleanUp && typeof HOOKS[CURRENT_HOOK_ID].cleanUp !== "function") {
           throw new Error("useEffect must be return function");
         }
-        HOOKS[CURRENT_HOOK_ID].work = fn;
         return true;
       }
     });
@@ -391,8 +394,12 @@ const useEffect = (fn, arr) => {
       throw new Error("useEffect must be return function");
     }
   } else if (!HOOKS[CURRENT_HOOK_ID].beforeArr.length) {
-    if (typeof HOOKS[CURRENT_HOOK_ID].cleanUp === "function") HOOKS[CURRENT_HOOK_ID].cleanUp();
-    HOOKS[CURRENT_HOOK_ID].work = () => {};
+   if (typeof HOOKS[CURRENT_HOOK_ID].cleanUp === "function") HOOKS[CURRENT_HOOK_ID].cleanUp();
+    HOOKS[CURRENT_HOOK_ID].work = fn;
+    HOOKS[CURRENT_HOOK_ID].cleanUp = HOOKS[CURRENT_HOOK_ID].work();
+    if (HOOKS[CURRENT_HOOK_ID].cleanUp && typeof HOOKS[CURRENT_HOOK_ID].cleanUp !== "function") {
+      throw new Error("useEffect must be return function");
+    }
   }
 };
 


### PR DESCRIPTION
- useEffect 함수가 직전 함수를 저장하여 직전 상태로 랜더링 되는 문제 해결
- useEffect의 콜백함수내에 랜더링 함수가 호출될시 내부에 랜더링 함수로 변경이 안되는 문제 해결

## :lock: 관련 이슈(닫을 이슈)
- #43 
